### PR TITLE
Collider inconsistencies bug

### DIFF
--- a/Assets/Prafabs/Player.prefab
+++ b/Assets/Prafabs/Player.prefab
@@ -108,8 +108,9 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 64
   _detectorCount: 4
-  _detectionRayLength: 0.1
+  _detectionRayLength: 0.07
   _rayBuffer: 0.1
+  _colGap: 0.03
   _acceleration: 60
   _moveClamp: 7
   _deAcceleration: 35
@@ -118,12 +119,12 @@ MonoBehaviour:
   _minFallAccel: 40
   _maxFallAccel: 60
   _jumpVelocity: 15
+  _wallJumpVelocity: {x: 20, y: 13}
   _jumpApexThreshold: 15
   _coyoteTimeThreshold: 0.1
   _jumpBuffer: 0.1
   _jumpEndEarlyGravityModifier: 3
-  _clingDuration: 0.15
-  _wallJumpVelocity: {x: 158.9, y: 10}
+  _clingDuration: 0.2
   _freeColliderIterations: 10
 --- !u!114 &2968947467466690203
 MonoBehaviour:

--- a/Assets/Scenes/DemoScene.unity
+++ b/Assets/Scenes/DemoScene.unity
@@ -849,18 +849,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8617720351884008124, guid: 79e1b549a5b53d84f81285bef4359058, type: 3}
-      propertyPath: _clingDuration
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8617720351884008124, guid: 79e1b549a5b53d84f81285bef4359058, type: 3}
-      propertyPath: _wallJumpVelocity.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 8617720351884008124, guid: 79e1b549a5b53d84f81285bef4359058, type: 3}
-      propertyPath: _wallJumpVelocity.y
-      value: 10
-      objectReference: {fileID: 0}
     - target: {fileID: 8617720351884008127, guid: 79e1b549a5b53d84f81285bef4359058, type: 3}
       propertyPath: m_Name
       value: Player

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -77,6 +77,8 @@ public class PlayerController : MonoBehaviour, IPlayerController
     [SerializeField] private int _detectorCount = 3;
     [SerializeField] private float _detectionRayLength = 0.1f;
     [SerializeField] [Range(0.1f, 0.3f)] private float _rayBuffer = 0.1f; // Prevents side detectors hitting the ground
+    [Tooltip("consistent spacing between player collider and colliders")]
+    [SerializeField] private float _colGap = 0.1f;
 
     private RayRange _raysUp, _raysRight, _raysDown, _raysLeft;
     private float _colUp, _colRight, _colDown, _colLeft; // IMPORTANT: collision distance ; -1 = no collision
@@ -214,12 +216,21 @@ public class PlayerController : MonoBehaviour, IPlayerController
         // clamped by max frame movement
         _currentHorizontalSpeed = Mathf.Clamp(_currentHorizontalSpeed, -_moveClamp, _moveClamp);
 
-        if (_currentHorizontalSpeed > 0 && _colRight!=NO_COL || _currentHorizontalSpeed < 0 && _colLeft!=NO_COL)
+        if (_currentHorizontalSpeed > 0 && _colRight!=NO_COL) 
         {
             // Don't walk through walls
             _currentHorizontalSpeed = 0;
 
-            // ADD CODE HERE TO SNAP TO LEFT/RIGHT WALL
+            // snap to right wall
+            transform.position += new Vector3(_colRight - _colGap, 0, 0);
+        }
+        if(_currentHorizontalSpeed < 0 && _colLeft != NO_COL)
+        {
+            // Don't walk through walls
+            _currentHorizontalSpeed = 0;
+
+            // snap to left wall
+            transform.position += new Vector3(_colGap -_colLeft, 0, 0);
         }
     }
 

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -247,8 +247,14 @@ public class PlayerController : MonoBehaviour, IPlayerController
     {
         if (_colDown!=NO_COL)
         {
-            // Move out of the ground
-            if (_currentVerticalSpeed < 0) _currentVerticalSpeed = 0;
+            if (_currentVerticalSpeed < 0)
+            {
+                // Don't fall through floor (it is solid)
+                _currentVerticalSpeed = 0;
+
+                // snap to ground (consistent height/gap)
+                transform.position += new Vector3(0, _colGap - _colDown, 0);
+            }
         }
         else
         {


### PR DESCRIPTION
replaced boolean collision check variables with floats storing collision distance. These distances are used for collision snapping for left, right, and bottom collisions to ensure consistency.

To ensure consistency and prevent buggy corner behavior, collisions are set to a consistent gap distance of 0.03 Unity units. Although not perfect it should be an improvement from prior appearance.